### PR TITLE
feat: tag-based grouping for VPC IP utilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ A web application that visualizes IP address allocation and fragmentation in AWS
 - `GET /api/vpcs` - List all VPCs
 - `GET /api/vpc/<vpc_id>/subnets` - Get subnets for a VPC with statistics
 - `GET /api/subnet/<subnet_id>/ips` - Get detailed IP allocation map for a subnet
+- `GET /api/vpc/<vpc_id>/tags` - Discover tag keys across VPC resources
+- `GET /api/vpc/<vpc_id>/tag-groups?tag_key=` - Get IP utilization grouped by tag values
 
 ## EKS IP Tracking
 
@@ -129,13 +131,79 @@ The application needs the following EC2 permissions:
       "Action": [
         "ec2:DescribeVpcs",
         "ec2:DescribeSubnets",
-        "ec2:DescribeNetworkInterfaces"
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
+        "ec2:GetSubnetCidrReservations"
       ],
       "Resource": "*"
     }
   ]
 }
 ```
+
+### EKS Deployment with IRSA
+
+When deploying to EKS, use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to grant the pod AWS permissions without using node-level credentials.
+
+**1. Associate an OIDC provider with your cluster** (one-time setup):
+
+```bash
+eksctl utils associate-iam-oidc-provider \
+  --cluster <cluster-name> \
+  --region <region> \
+  --approve
+```
+
+**2. Create an IAM policy:**
+
+```bash
+aws iam create-policy \
+  --policy-name FragmentationViewerPolicy \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DescribeVpcs",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeInstances",
+          "ec2:DescribeRegions",
+          "ec2:GetSubnetCidrReservations"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }'
+```
+
+**3. Create a Kubernetes service account with the IAM role:**
+
+```bash
+eksctl create iamserviceaccount \
+  --name fragmentation-viewer-sa \
+  --namespace default \
+  --cluster <cluster-name> \
+  --region <region> \
+  --attach-policy-arn arn:aws:iam::<account-id>:policy/FragmentationViewerPolicy \
+  --approve
+```
+
+**4. Reference the service account in your deployment:**
+
+```yaml
+spec:
+  template:
+    spec:
+      serviceAccountName: fragmentation-viewer-sa
+      containers:
+        - name: fragmentation-viewer
+          image: <account-id>.dkr.ecr.<region>.amazonaws.com/vpc-ip-viewer:latest
+```
+
+Sample Kubernetes manifests are provided in the `k8s/` directory.
 
 ## Screenshot
 ![](./img/fragmentation.png "Visualizer")

--- a/app.py
+++ b/app.py
@@ -136,6 +136,70 @@ def get_all_eni_ips(enis):
     return subnet_ips
 
 
+def get_instance_tags(ec2_client, vpc_id):
+    """
+    Fetch all instances in a VPC and return a dict of {instance_id: {tag_key: tag_value}}.
+    Returns empty dict if DescribeInstances fails (e.g. insufficient permissions).
+    """
+    try:
+        paginator = ec2_client.get_paginator('describe_instances')
+        pages = paginator.paginate(
+            Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]
+        )
+
+        instance_tags = {}
+        for page in pages:
+            for reservation in page['Reservations']:
+                for instance in reservation['Instances']:
+                    instance_id = instance['InstanceId']
+                    tags = {tag['Key']: tag['Value'] for tag in instance.get('Tags', [])}
+                    instance_tags[instance_id] = tags
+
+        logger.info(f"Fetched tags for {len(instance_tags)} instances in VPC {vpc_id}")
+        return instance_tags
+    except Exception as e:
+        logger.warning(f"Could not fetch instance tags (may lack ec2:DescribeInstances permission): {str(e)}")
+        return {}
+
+
+def resolve_tag_for_ip(tag_key, eni, instance_tags, subnet_tags, vpc_tags):
+    """
+    Resolve a tag value for a given IP's ENI using precedence:
+    ENI tags > Instance tags > Subnet tags > VPC tags.
+    Returns the tag value string, or None if not found at any level.
+
+    Args:
+        tag_key: The tag key to look up (e.g. 'team')
+        eni: The ENI dict from DescribeNetworkInterfaces
+        instance_tags: Dict of {instance_id: {tag_key: tag_value}}
+        subnet_tags: Dict of {subnet_id: {tag_key: tag_value}}
+        vpc_tags: Dict of {tag_key: tag_value} for the VPC
+    """
+    # Level 1: ENI tags
+    eni_tags = {tag['Key']: tag['Value'] for tag in eni.get('TagSet', [])}
+    if tag_key in eni_tags:
+        return eni_tags[tag_key]
+
+    # Level 2: Parent instance tags
+    attachment = eni.get('Attachment', {})
+    instance_id = attachment.get('InstanceId')
+    if instance_id and instance_id in instance_tags:
+        if tag_key in instance_tags[instance_id]:
+            return instance_tags[instance_id][tag_key]
+
+    # Level 3: Subnet tags
+    subnet_id = eni.get('SubnetId')
+    if subnet_id and subnet_id in subnet_tags:
+        if tag_key in subnet_tags[subnet_id]:
+            return subnet_tags[subnet_id][tag_key]
+
+    # Level 4: VPC tags
+    if tag_key in vpc_tags:
+        return vpc_tags[tag_key]
+
+    return None
+
+
 def calculate_fragmentation(used_ips, total_ips, available_count):
     """
     Calculate fragmentation metrics for a subnet optimized for /28 prefix allocation.
@@ -464,6 +528,219 @@ def get_subnet_ips(subnet_id):
         })
     except Exception as e:
         logger.error(f"Error fetching subnet IPs: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/vpc/<vpc_id>/tags')
+def get_vpc_tags(vpc_id):
+    """Discover all unique tag keys across ENIs, instances, subnets, and the VPC."""
+    try:
+        region = get_region_from_request()
+        ec2_client = get_ec2_client(region)
+
+        # Fetch the VPC to get its tags
+        vpc_response = ec2_client.describe_vpcs(VpcIds=[vpc_id])
+        vpc = vpc_response['Vpcs'][0]
+        vpc_tag_keys = {tag['Key'] for tag in vpc.get('Tags', [])}
+
+        # Fetch subnets and their tags
+        subnet_paginator = ec2_client.get_paginator('describe_subnets')
+        subnets_list = []
+        for page in subnet_paginator.paginate(Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]):
+            subnets_list.extend(page['Subnets'])
+        subnet_tag_keys = set()
+        for subnet in subnets_list:
+            for tag in subnet.get('Tags', []):
+                subnet_tag_keys.add(tag['Key'])
+
+        # Fetch ENIs and their tags
+        eni_paginator = ec2_client.get_paginator('describe_network_interfaces')
+        enis = []
+        for page in eni_paginator.paginate(Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]):
+            enis.extend(page['NetworkInterfaces'])
+        eni_tag_keys = set()
+        for eni in enis:
+            for tag in eni.get('TagSet', []):
+                eni_tag_keys.add(tag['Key'])
+
+        # Fetch instance tags
+        instance_tags = get_instance_tags(ec2_client, vpc_id)
+        instance_tag_keys = set()
+        for tags in instance_tags.values():
+            instance_tag_keys.update(tags.keys())
+
+        # Build result: for each unique tag key, record which sources have it and count resources
+        all_keys = vpc_tag_keys | subnet_tag_keys | eni_tag_keys | instance_tag_keys
+        result = []
+        for key in all_keys:
+            sources = []
+            resource_count = 0
+            if key in eni_tag_keys:
+                sources.append('eni')
+                resource_count += sum(
+                    1 for eni in enis
+                    if any(t['Key'] == key for t in eni.get('TagSet', []))
+                )
+            if key in instance_tag_keys:
+                sources.append('instance')
+                resource_count += sum(
+                    1 for tags in instance_tags.values()
+                    if key in tags
+                )
+            if key in subnet_tag_keys:
+                sources.append('subnet')
+                resource_count += sum(
+                    1 for s in subnets_list
+                    if any(t['Key'] == key for t in s.get('Tags', []))
+                )
+            if key in vpc_tag_keys:
+                sources.append('vpc')
+                resource_count += 1
+
+            result.append({
+                'key': key,
+                'sources': sources,
+                'resourceCount': resource_count
+            })
+
+        result.sort(key=lambda x: x['resourceCount'], reverse=True)
+        return jsonify(result)
+    except Exception as e:
+        logger.error(f"Error fetching VPC tags: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/vpc/<vpc_id>/tag-groups')
+def get_tag_groups(vpc_id):
+    """Get IP utilization grouped by values of a specified tag key."""
+    tag_key = request.args.get('tag_key')
+    if not tag_key:
+        return jsonify({'error': 'tag_key query parameter is required'}), 400
+
+    try:
+        region = get_region_from_request()
+        ec2_client = get_ec2_client(region)
+
+        # Fetch VPC for its tags
+        vpc_response = ec2_client.describe_vpcs(VpcIds=[vpc_id])
+        vpc = vpc_response['Vpcs'][0]
+        vpc_tags = {tag['Key']: tag['Value'] for tag in vpc.get('Tags', [])}
+
+        # Fetch subnets
+        subnet_paginator = ec2_client.get_paginator('describe_subnets')
+        subnets_list = []
+        for page in subnet_paginator.paginate(Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]):
+            subnets_list.extend(page['Subnets'])
+        subnet_tags = {}
+        subnet_info = {}
+        for subnet in subnets_list:
+            sid = subnet['SubnetId']
+            subnet_tags[sid] = {tag['Key']: tag['Value'] for tag in subnet.get('Tags', [])}
+            subnet_info[sid] = {
+                'cidr': subnet['CidrBlock'],
+                'totalIps': ip_network(subnet['CidrBlock']).num_addresses,
+                'availableIps': subnet['AvailableIpAddressCount']
+            }
+
+        # Fetch ENIs
+        eni_paginator = ec2_client.get_paginator('describe_network_interfaces')
+        enis = []
+        for page in eni_paginator.paginate(Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]):
+            enis.extend(page['NetworkInterfaces'])
+
+        # Fetch instance tags
+        instance_tags = get_instance_tags(ec2_client, vpc_id)
+
+        # Build a map: eni_id -> eni (for tag resolution)
+        eni_map = {eni['NetworkInterfaceId']: eni for eni in enis}
+
+        # Extract all IPs from ENIs
+        subnet_ip_details = get_all_eni_ips(enis)
+
+        # Group IPs by tag value
+        # Structure: {tag_value: {subnet_id: [ip_strings]}}
+        groups = defaultdict(lambda: defaultdict(list))
+        # Track IP type counts per group
+        group_type_counts = defaultdict(lambda: {'primary': 0, 'secondary': 0, 'prefix_delegation': 0})
+
+        for subnet_id, ip_list in subnet_ip_details.items():
+            for ip_info in ip_list:
+                eni_id = ip_info.get('interfaceId')
+                eni = eni_map.get(eni_id, {})
+                tag_value = resolve_tag_for_ip(tag_key, eni, instance_tags, subnet_tags, vpc_tags)
+                group_name = tag_value if tag_value is not None else 'Untagged'
+
+                groups[group_name][subnet_id].append(ip_info['ip'])
+                ip_type = ip_info.get('type', 'primary')
+                if ip_type in group_type_counts[group_name]:
+                    group_type_counts[group_name][ip_type] += 1
+
+        # Calculate per-group stats
+        vpc_total_ips = sum(info['totalIps'] for info in subnet_info.values())
+        vpc_used_ips = sum(len(ips) for sid_ips in subnet_ip_details.values() for ips in [sid_ips])
+
+        group_results = []
+        for tag_value, subnet_ips in groups.items():
+            total_ips_used = sum(len(ips) for ips in subnet_ips.values())
+            subnet_ids = list(subnet_ips.keys())
+
+            # Weighted-average fragmentation across subnets
+            total_weight = 0
+            weighted_frag_sum = 0
+            combined_frag_details = {
+                'num_gaps': 0,
+                'avg_gap_size': 0,
+                'largest_gap': 0,
+                'usable_prefixes': 0
+            }
+
+            for sid, ips in subnet_ips.items():
+                if sid not in subnet_info:
+                    continue
+                info = subnet_info[sid]
+                frag_score, frag_details = calculate_fragmentation(
+                    ips, info['totalIps'], info['availableIps']
+                )
+                weight = info['totalIps']
+                weighted_frag_sum += frag_score * weight
+                total_weight += weight
+                combined_frag_details['num_gaps'] += frag_details.get('num_gaps', 0)
+                combined_frag_details['usable_prefixes'] += frag_details.get('usable_prefixes', 0)
+                combined_frag_details['largest_gap'] = max(
+                    combined_frag_details['largest_gap'],
+                    frag_details.get('largest_gap', 0)
+                )
+
+            avg_frag = round(weighted_frag_sum / total_weight, 2) if total_weight > 0 else 0
+
+            utilization_percent = round(
+                (total_ips_used / vpc_used_ips) * 100, 2
+            ) if vpc_used_ips > 0 else 0
+
+            type_counts = group_type_counts[tag_value]
+            group_results.append({
+                'tagValue': tag_value,
+                'totalIpsUsed': total_ips_used,
+                'primaryIps': type_counts['primary'],
+                'secondaryIps': type_counts['secondary'],
+                'prefixDelegationIps': type_counts['prefix_delegation'],
+                'subnetCount': len(subnet_ids),
+                'subnetIds': subnet_ids,
+                'utilizationPercent': utilization_percent,
+                'fragmentationScore': avg_frag,
+                'fragmentationDetails': combined_frag_details
+            })
+
+        group_results.sort(key=lambda x: x['totalIpsUsed'], reverse=True)
+
+        return jsonify({
+            'tagKey': tag_key,
+            'groups': group_results,
+            'vpcTotalIps': vpc_total_ips,
+            'vpcUsedIps': vpc_used_ips
+        })
+    except Exception as e:
+        logger.error(f"Error fetching tag groups: {str(e)}")
         return jsonify({'error': str(e)}), 500
 
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -190,6 +190,65 @@
   background-color: #374151;
 }
 
+.view-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid #334155;
+}
+
+.view-tab {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+}
+
+.view-tab:hover {
+  color: #e2e8f0;
+}
+
+.view-tab.active {
+  color: #667eea;
+  border-bottom-color: #667eea;
+}
+
+.filter-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background-color: #1e3a5f;
+  border: 1px solid #2563eb;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  color: #93c5fd;
+}
+
+.filter-banner button {
+  background: none;
+  border: 1px solid #93c5fd;
+  color: #93c5fd;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.2s;
+}
+
+.filter-banner button:hover {
+  background-color: #2563eb;
+  color: white;
+}
+
 @media (max-width: 1024px) {
   .main-content {
     grid-template-columns: 1fr;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,8 @@ import VpcSelector from './components/VpcSelector';
 import SubnetList from './components/SubnetList';
 import IpVisualization from './components/IpVisualization';
 import Statistics from './components/Statistics';
+import TagGroupSelector from './components/TagGroupSelector';
+import TagGroupList from './components/TagGroupList';
 
 const API_URL = process.env.REACT_APP_API_URL || '';
 
@@ -19,6 +21,12 @@ function App() {
   const [ipData, setIpData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  const [viewMode, setViewMode] = useState('subnets');
+  const [tagKeys, setTagKeys] = useState([]);
+  const [selectedTagKey, setSelectedTagKey] = useState(null);
+  const [tagGroups, setTagGroups] = useState(null);
+  const [subnetFilter, setSubnetFilter] = useState(null);
 
   // Fetch regions on mount
   useEffect(() => {
@@ -47,6 +55,12 @@ function App() {
       setSelectedSubnet(null);
       setIpData(null);
     }
+    // Reset tag state on VPC change
+    setViewMode('subnets');
+    setTagKeys([]);
+    setSelectedTagKey(null);
+    setTagGroups(null);
+    setSubnetFilter(null);
   }, [selectedVpc]);
 
   // Fetch IP data when subnet is selected
@@ -132,6 +146,60 @@ function App() {
     }
   };
 
+  const fetchTagKeys = async (vpcId) => {
+    if (!selectedRegion) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await axios.get(`${API_URL}/api/vpc/${vpcId}/tags`, {
+        params: { region: selectedRegion.id }
+      });
+      setTagKeys(response.data);
+    } catch (err) {
+      setError('Failed to fetch tag keys: ' + err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchTagGroups = async (vpcId, tagKey) => {
+    if (!selectedRegion) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await axios.get(`${API_URL}/api/vpc/${vpcId}/tag-groups`, {
+        params: { region: selectedRegion.id, tag_key: tagKey }
+      });
+      setTagGroups(response.data);
+    } catch (err) {
+      setError('Failed to fetch tag groups: ' + err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleViewModeChange = (mode) => {
+    setViewMode(mode);
+    setSubnetFilter(null);
+    if (mode === 'tags' && selectedVpc && tagKeys.length === 0) {
+      fetchTagKeys(selectedVpc.id);
+    }
+  };
+
+  const handleTagKeySelect = (tagKey) => {
+    setSelectedTagKey(tagKey);
+    if (tagKey && selectedVpc) {
+      fetchTagGroups(selectedVpc.id, tagKey);
+    } else {
+      setTagGroups(null);
+    }
+  };
+
+  const handleGroupClick = (group) => {
+    setSubnetFilter(group.subnetIds);
+    setViewMode('subnets');
+  };
+
   return (
     <div className="App">
       <header className="App-header">
@@ -170,12 +238,54 @@ function App() {
         {selectedVpc && (
           <div className="main-content">
             <div className="left-panel">
-              <SubnetList
-                subnets={subnets}
-                selectedSubnet={selectedSubnet}
-                onSelect={setSelectedSubnet}
-                loading={loading}
-              />
+              <div className="view-tabs">
+                <button
+                  className={`view-tab ${viewMode === 'subnets' ? 'active' : ''}`}
+                  onClick={() => handleViewModeChange('subnets')}
+                >
+                  Subnets
+                </button>
+                <button
+                  className={`view-tab ${viewMode === 'tags' ? 'active' : ''}`}
+                  onClick={() => handleViewModeChange('tags')}
+                >
+                  Tag Groups
+                </button>
+              </div>
+
+              {subnetFilter && viewMode === 'subnets' && (
+                <div className="filter-banner">
+                  Filtered to {subnetFilter.length} subnet{subnetFilter.length !== 1 ? 's' : ''}
+                  <button onClick={() => setSubnetFilter(null)}>Clear filter</button>
+                </div>
+              )}
+
+              {viewMode === 'subnets' ? (
+                <SubnetList
+                  subnets={subnetFilter
+                    ? subnets.filter(s => subnetFilter.includes(s.id))
+                    : subnets
+                  }
+                  selectedSubnet={selectedSubnet}
+                  onSelect={setSelectedSubnet}
+                  loading={loading}
+                />
+              ) : (
+                <>
+                  <TagGroupSelector
+                    tagKeys={tagKeys}
+                    selectedTagKey={selectedTagKey}
+                    onSelect={handleTagKeySelect}
+                    loading={loading}
+                  />
+                  <TagGroupList
+                    tagGroups={tagGroups?.groups || []}
+                    vpcUsedIps={tagGroups?.vpcUsedIps || 0}
+                    onGroupClick={handleGroupClick}
+                    loading={loading}
+                  />
+                </>
+              )}
             </div>
 
             <div className="right-panel">

--- a/frontend/src/components/TagGroupList.css
+++ b/frontend/src/components/TagGroupList.css
@@ -1,0 +1,72 @@
+.tag-group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tag-group-list h3 {
+  color: #e2e8f0;
+  margin-bottom: 0.5rem;
+}
+
+.tag-group-items {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tag-group-item {
+  padding: 1rem;
+  border: 2px solid #334155;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.tag-group-item:hover {
+  border-color: #667eea;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.2);
+}
+
+.tag-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.tag-group-header h4 {
+  margin: 0;
+  color: #e2e8f0;
+  font-size: 1rem;
+}
+
+.tag-group-subnet-count {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  background-color: #1f2937;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
+
+.tag-group-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.tag-group-ip-types {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.tag-group-list-loading,
+.tag-group-list-empty {
+  text-align: center;
+  padding: 2rem;
+  color: #94a3b8;
+}

--- a/frontend/src/components/TagGroupList.js
+++ b/frontend/src/components/TagGroupList.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import './TagGroupList.css';
+
+function TagGroupList({ tagGroups, vpcUsedIps, onGroupClick, loading }) {
+  if (loading) {
+    return <div className="tag-group-list-loading">Loading tag groups...</div>;
+  }
+
+  if (!tagGroups || tagGroups.length === 0) {
+    return <div className="tag-group-list-empty">No tag groups found. Select a tag key above.</div>;
+  }
+
+  const getFragmentationColor = (score) => {
+    if (score < 20) return '#10b981';
+    if (score < 50) return '#f59e0b';
+    return '#ef4444';
+  };
+
+  return (
+    <div className="tag-group-list">
+      <h3>Tag Groups ({tagGroups.length})</h3>
+      <div className="tag-group-items">
+        {tagGroups.map(group => (
+          <div
+            key={group.tagValue}
+            className="tag-group-item"
+            onClick={() => onGroupClick(group)}
+          >
+            <div className="tag-group-header">
+              <h4>{group.tagValue}</h4>
+              <span className="tag-group-subnet-count">
+                {group.subnetCount} subnet{group.subnetCount !== 1 ? 's' : ''}
+              </span>
+            </div>
+
+            <div className="tag-group-stats">
+              <div className="stat">
+                <span className="stat-label">IPs Used:</span>
+                <span className="stat-value">{group.totalIpsUsed}</span>
+              </div>
+              <div className="stat">
+                <span className="stat-label">Share of VPC:</span>
+                <span className="stat-value">{group.utilizationPercent.toFixed(1)}%</span>
+              </div>
+            </div>
+
+            <div className="tag-group-ip-types">
+              {group.primaryIps > 0 && (
+                <span className="ip-type-badge primary">Primary: {group.primaryIps}</span>
+              )}
+              {group.secondaryIps > 0 && (
+                <span className="ip-type-badge secondary">Secondary: {group.secondaryIps}</span>
+              )}
+              {group.prefixDelegationIps > 0 && (
+                <span className="ip-type-badge prefix">Prefix: {group.prefixDelegationIps}</span>
+              )}
+            </div>
+
+            <div className="fragmentation-score">
+              <span className="frag-label">Fragmentation:</span>
+              <div className="frag-bar-container">
+                <div
+                  className="frag-bar"
+                  style={{
+                    width: `${group.fragmentationScore}%`,
+                    backgroundColor: getFragmentationColor(group.fragmentationScore)
+                  }}
+                />
+              </div>
+              <span className="frag-value">{group.fragmentationScore.toFixed(1)}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default TagGroupList;

--- a/frontend/src/components/TagGroupSelector.css
+++ b/frontend/src/components/TagGroupSelector.css
@@ -1,0 +1,44 @@
+.tag-group-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tag-group-selector label {
+  font-weight: 600;
+  color: #e5e7eb;
+  font-size: 0.9rem;
+}
+
+.tag-group-selector select {
+  padding: 0.75rem;
+  border: 2px solid #374151;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background-color: #1f2937;
+  color: #f3f4f6;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.tag-group-selector select:hover:not(:disabled) {
+  border-color: #667eea;
+}
+
+.tag-group-selector select:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.tag-group-selector select:disabled {
+  background-color: #374151;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.tag-group-selector option {
+  background-color: #1f2937;
+  color: #f3f4f6;
+}

--- a/frontend/src/components/TagGroupSelector.js
+++ b/frontend/src/components/TagGroupSelector.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import './TagGroupSelector.css';
+
+function TagGroupSelector({ tagKeys, selectedTagKey, onSelect, loading }) {
+  return (
+    <div className="tag-group-selector">
+      <label htmlFor="tag-key-select">Group by Tag:</label>
+      <select
+        id="tag-key-select"
+        value={selectedTagKey || ''}
+        onChange={(e) => onSelect(e.target.value || null)}
+        disabled={loading || tagKeys.length === 0}
+      >
+        <option value="">-- Select a Tag Key --</option>
+        {tagKeys.map(tag => (
+          <option key={tag.key} value={tag.key}>
+            {tag.key} ({tag.sources.join(', ')}) - {tag.resourceCount} resources
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export default TagGroupSelector;

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fragmentation-viewer
+  namespace: default
+  labels:
+    app: fragmentation-viewer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fragmentation-viewer
+  template:
+    metadata:
+      labels:
+        app: fragmentation-viewer
+    spec:
+      serviceAccountName: fragmentation-viewer-sa
+      containers:
+        - name: fragmentation-viewer
+          image: <account-id>.dkr.ecr.<region>.amazonaws.com/<repo>:latest
+          ports:
+            - containerPort: 5000
+          env:
+            - name: AWS_DEFAULT_REGION
+              value: "us-east-1"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 5000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fragmentation-viewer
+  namespace: default
+  labels:
+    app: fragmentation-viewer
+spec:
+  type: LoadBalancer
+  selector:
+    app: fragmentation-viewer
+  ports:
+    - port: 80
+      targetPort: 5000
+      protocol: TCP


### PR DESCRIPTION
Add the ability to view IP usage grouped by AWS resource tags (team, application, environment). Users select a VPC, toggle to a "Tag Groups" tab, pick a tag key from a dynamically populated dropdown, and see IP utilization summary cards grouped by that tag's values. Clicking a group filters the subnet list to show only matching subnets.

Backend:
- Two new API endpoints: tag key discovery and tag-grouped utilization
- Tag resolution with ENI > Instance > Subnet > VPC precedence
- Paginated AWS API calls for large VPCs
- New IAM permission: ec2:DescribeInstances

Frontend:
- TagGroupSelector dropdown component
- TagGroupList summary card component with fragmentation scores
- Tab toggle (Subnets / Tag Groups) in the left panel
- Click-to-filter from tag group to subnet list

Deployment:
- Kubernetes manifests for EKS deployment
- IRSA setup guide with required IAM policy