### PR TITLE
Add Textual TUI and extract shared VPC data module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,34 @@ A web application that visualizes IP address allocation and fragmentation in AWS
 
 ## Architecture
 
-- **Backend**: Flask API that queries AWS EC2 APIs for VPC, subnet, and ENI information
-- **Frontend**: React application with visual IP allocation grid
+- **Shared core**: `vpc_data.py` holds the boto3 EC2 queries and fragmentation math, reused by both front ends
+- **Backend**: Flask API (`app.py`) that exposes the shared core over `/api/*`
+- **Web frontend**: React application with visual IP allocation grid
+- **Terminal UI**: `tui.py`, a keyboard-driven [Textual](https://textual.textualize.io/) app that renders the same disk-defrag view in your terminal
 - **Deployment**: Containerized with Docker, ready for ECS/EKS deployment
+
+## Terminal UI (TUI)
+
+Prefer the terminal? Run the TUI instead of the web stack — it uses your AWS
+credentials directly, no server required.
+
+```bash
+./setup.sh && source venv/bin/activate   # or: pip install -r requirements.txt
+python tui.py                            # or: textual run tui.py
+```
+
+- Pick a **region** and **VPC** from the dropdowns at the top.
+- Select a **subnet** from the table (↑/↓, `Enter`) to load its IP map.
+- Move the cursor over the **IP grid** with the arrow keys or `h`/`j`/`k`/`l`
+  (`Home`/`End` jump to the first/last IP). The panel below shows details for
+  the highlighted IP — the TUI equivalent of the web hover tooltip. The grid
+  reflows to fill the map panel's width, so widening your terminal shows more
+  IPs per row.
+- Press `r` to refresh the current view, `q` to quit.
+
+Colors match the web legend: primary (blue), secondary (cyan), prefix
+delegation (purple), CIDR reservation (amber/orange), AWS reserved (gray), and
+free (dim gray).
 
 ## Prerequisites
 

--- a/app.py
+++ b/app.py
@@ -7,236 +7,28 @@ import logging
 import os
 from flask import Flask, jsonify, send_from_directory, request
 from flask_cors import CORS
-import boto3
-from ipaddress import ip_network, ip_address
-from collections import defaultdict
 from dotenv import load_dotenv
+
+from vpc_data import (
+    DEFAULT_REGION,
+    list_regions,
+    list_vpcs,
+    get_vpc_subnets,
+    get_subnet_ip_map,
+)
 
 load_dotenv()
 
 app = Flask(__name__, static_folder='frontend/build', static_url_path='')
 CORS(app)
 
-# Default region
-DEFAULT_REGION = os.getenv('AWS_DEFAULT_REGION', 'us-east-1')
-
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def get_ec2_client(region=None):
-    """Get EC2 client for the specified region"""
-    region = region or DEFAULT_REGION
-    return boto3.client('ec2', region_name=region)
 
 
 def get_region_from_request():
     """Extract region from request query parameters or headers"""
     return request.args.get('region') or request.headers.get('X-AWS-Region') or DEFAULT_REGION
-
-
-def get_reserved_ips(cidr_block):
-    """AWS reserves first 4 and last IP in each subnet"""
-    network = ip_network(cidr_block)
-    reserved = set()
-
-    # First 4 IPs (.0, .1, .2, .3) and last IP (broadcast)
-    reserved.add(str(network.network_address))
-    reserved.add(str(network.network_address + 1))
-    reserved.add(str(network.network_address + 2))
-    reserved.add(str(network.network_address + 3))
-    reserved.add(str(network.broadcast_address))
-
-    return reserved
-
-
-def get_subnet_cidr_reservations(ec2_client, subnet_id):
-    """
-    Get CIDR reservations for a subnet.
-    Returns a dict mapping IP addresses to reservation details.
-    """
-    try:
-        response = ec2_client.get_subnet_cidr_reservations(SubnetId=subnet_id)
-
-        reservation_ips = {}
-        for reservation in response.get('SubnetIpv4CidrReservations', []):
-            cidr = reservation['Cidr']
-            reservation_type = reservation['ReservationType']  # 'explicit' or 'prefix'
-            description = reservation.get('Description', '')
-            reservation_id = reservation['SubnetCidrReservationId']
-
-            logger.info(f"Found CIDR reservation: {cidr} ({reservation_type}) - {description}")
-
-            # Get all IPs in the reserved CIDR block
-            try:
-                reserved_network = ip_network(cidr)
-                for ip in reserved_network:
-                    reservation_ips[str(ip)] = {
-                        'cidr': cidr,
-                        'type': reservation_type,
-                        'description': description,
-                        'reservationId': reservation_id
-                    }
-            except Exception as e:
-                logger.error(f"Error processing reservation CIDR {cidr}: {str(e)}")
-
-        return reservation_ips
-    except Exception as e:
-        logger.error(f"Error fetching subnet CIDR reservations: {str(e)}")
-        return {}
-
-
-def get_all_eni_ips(enis):
-    """
-    Extract all IPs from ENIs including:
-    - Primary private IPs
-    - Secondary private IPs (used by EKS pods without dedicated ENIs)
-    - IPs from IPv4 prefixes (prefix delegation for EKS)
-    """
-    subnet_ips = defaultdict(list)
-
-    for eni in enis:
-        subnet_id = eni['SubnetId']
-        interface_id = eni['NetworkInterfaceId']
-        description = eni.get('Description', '')
-
-        # Get all private IP addresses (primary and secondary)
-        for private_ip_info in eni.get('PrivateIpAddresses', []):
-            ip = private_ip_info['PrivateIpAddress']
-            subnet_ips[subnet_id].append({
-                'ip': ip,
-                'type': 'primary' if private_ip_info.get('Primary', False) else 'secondary',
-                'status': eni['Status'],
-                'description': description,
-                'interfaceId': interface_id,
-                'attachmentStatus': eni.get('Attachment', {}).get('Status', 'detached')
-            })
-
-        # Get IPs from IPv4 prefixes (EKS prefix delegation)
-        for prefix in eni.get('Ipv4Prefixes', []):
-            prefix_cidr = prefix['Ipv4Prefix']
-            logger.info(f"Found IPv4 prefix: {prefix_cidr} on ENI {interface_id}")
-
-            # Each prefix is typically a /28 (16 IPs) assigned to the ENI
-            # Pods will use IPs from this prefix
-            try:
-                prefix_network = ip_network(prefix_cidr)
-                for ip in prefix_network.hosts():
-                    subnet_ips[subnet_id].append({
-                        'ip': str(ip),
-                        'type': 'prefix_delegation',
-                        'status': 'prefix',
-                        'description': f"{description} (Prefix: {prefix_cidr})",
-                        'interfaceId': interface_id,
-                        'attachmentStatus': 'prefix_assigned'
-                    })
-            except Exception as e:
-                logger.error(f"Error processing prefix {prefix_cidr}: {str(e)}")
-
-    return subnet_ips
-
-
-def calculate_fragmentation(used_ips, total_ips, available_count):
-    """
-    Calculate fragmentation metrics for a subnet optimized for /28 prefix allocation.
-    Returns a fragmentation score (0-100) where:
-    - 0 = Low fragmentation (can allocate many /28 blocks efficiently)
-    - 100 = High fragmentation (most available IPs are wasted in unusable fragments)
-
-    The score measures what percentage of available IPs are in fragments too small
-    to fit a /28 block (16 IPs). This directly reflects allocation efficiency.
-    """
-    PREFIX_SIZE = 16  # /28 block size for EKS prefix delegation
-
-    if total_ips == 0 or available_count == 0:
-        return 0, {'num_gaps': 0, 'avg_gap_size': 0, 'largest_gap': 0, 'gaps': [], 'usable_prefixes': 0}
-
-    if len(used_ips) == 0:
-        # No IPs used means no fragmentation
-        usable_prefixes = available_count // PREFIX_SIZE
-        return 0, {
-            'num_gaps': 0,
-            'avg_gap_size': 0,
-            'largest_gap': available_count,
-            'gaps': [],
-            'usable_prefixes': usable_prefixes
-        }
-
-    # Sort used IPs by their integer representation
-    sorted_used = sorted([int(ip_address(ip)) for ip in used_ips])
-
-    logger.info(f"Fragmentation calc: total_ips={total_ips}, available={available_count}, used={len(used_ips)}")
-    logger.info(f"Used IP range: {ip_address(sorted_used[0])} to {ip_address(sorted_used[-1])}")
-
-    # Find all free blocks (gaps between used IPs + edge space)
-    gaps = []
-    for i in range(len(sorted_used) - 1):
-        gap_size = sorted_used[i + 1] - sorted_used[i] - 1
-        if gap_size > 0:
-            gaps.append(gap_size)
-
-    # Total IPs in gaps between used IPs
-    total_gap_ips = sum(gaps)
-
-    # The remaining available IPs are in contiguous blocks outside the used IP range
-    edge_free_ips = available_count - total_gap_ips
-
-    # All free blocks = gaps + edge block
-    all_free_blocks = gaps + ([edge_free_ips] if edge_free_ips > 0 else [])
-
-    # Calculate how many /28 prefixes can actually be allocated
-    usable_prefixes = sum(block // PREFIX_SIZE for block in all_free_blocks)
-
-    # Calculate how many /28 prefixes COULD be allocated if perfectly contiguous
-    theoretical_prefixes = available_count // PREFIX_SIZE
-
-    # Calculate wasted IPs (IPs in fragments too small for /28)
-    wasted_ips = sum(block % PREFIX_SIZE if block < PREFIX_SIZE else 0
-                     for block in all_free_blocks)
-    # Add the remainder IPs from blocks that can fit prefixes
-    wasted_ips += sum(block % PREFIX_SIZE for block in all_free_blocks if block >= PREFIX_SIZE)
-
-    logger.info(f"Gaps: {len(gaps)} gaps totaling {total_gap_ips} IPs")
-    logger.info(f"Free blocks: {sorted(all_free_blocks, reverse=True)[:5]}")
-    logger.info(f"Can allocate {usable_prefixes} /28 prefixes (theoretical max: {theoretical_prefixes})")
-    logger.info(f"Wasted IPs: {wasted_ips}/{available_count}")
-
-    # Calculate metrics
-    num_free_blocks = len(all_free_blocks)
-    largest_free_block = max(all_free_blocks) if all_free_blocks else 0
-    avg_block_size = sum(all_free_blocks) / num_free_blocks if num_free_blocks > 0 else 0
-
-    # If all free space is in one block, fragmentation is minimal
-    if num_free_blocks <= 1:
-        # Still calculate score based on wasted remainder
-        waste_percentage = (wasted_ips / available_count) * 100 if available_count > 0 else 0
-        return round(waste_percentage, 2), {
-            'num_gaps': 0,
-            'avg_gap_size': 0,
-            'largest_gap': largest_free_block,
-            'gaps': [],
-            'usable_prefixes': usable_prefixes
-        }
-
-    # Fragmentation score: percentage of IPs that can't be used due to fragmentation
-    # This accounts for both small fragments AND remainder waste
-    if theoretical_prefixes > 0:
-        # How many prefixes are lost due to fragmentation?
-        lost_prefixes = theoretical_prefixes - usable_prefixes
-        fragmentation_score = (lost_prefixes / theoretical_prefixes) * 100
-    else:
-        # If we can't even fit one /28, fragmentation is maximum
-        fragmentation_score = 100
-
-    logger.info(f"Fragmentation score: {fragmentation_score:.1f}% (lost {theoretical_prefixes - usable_prefixes}/{theoretical_prefixes} possible /28 blocks)")
-
-    return round(fragmentation_score, 2), {
-        'num_gaps': len(gaps),
-        'avg_gap_size': round(avg_block_size, 2),
-        'largest_gap': largest_free_block,
-        'gaps': sorted(all_free_blocks, reverse=True)[:10],
-        'usable_prefixes': usable_prefixes
-    }
 
 
 @app.route('/')
@@ -254,19 +46,7 @@ def serve():
 def get_regions():
     """Get all available AWS regions"""
     try:
-        ec2_client = boto3.client('ec2', region_name='us-east-1')
-        response = ec2_client.describe_regions(AllRegions=False)
-        regions = [
-            {
-                'id': region['RegionName'],
-                'name': region['RegionName'],
-                'endpoint': region['Endpoint']
-            }
-            for region in response['Regions']
-        ]
-        # Sort by region name
-        regions.sort(key=lambda x: x['name'])
-        return jsonify(regions)
+        return jsonify(list_regions())
     except Exception as e:
         logger.error(f"Error fetching regions: {str(e)}")
         return jsonify({'error': str(e)}), 500
@@ -277,21 +57,7 @@ def get_vpcs():
     """Get all VPCs in the account for the specified region"""
     try:
         region = get_region_from_request()
-        ec2_client = get_ec2_client(region)
-        response = ec2_client.describe_vpcs()
-        vpcs = []
-
-        for vpc in response['Vpcs']:
-            name = next((tag['Value'] for tag in vpc.get('Tags', [])
-                        if tag['Key'] == 'Name'), vpc['VpcId'])
-            vpcs.append({
-                'id': vpc['VpcId'],
-                'name': name,
-                'cidr': vpc['CidrBlock'],
-                'state': vpc['State']
-            })
-
-        return jsonify(vpcs)
+        return jsonify(list_vpcs(region))
     except Exception as e:
         logger.error(f"Error fetching VPCs: {str(e)}")
         return jsonify({'error': str(e)}), 500
@@ -302,88 +68,7 @@ def get_subnets(vpc_id):
     """Get all subnets for a VPC with usage statistics"""
     try:
         region = get_region_from_request()
-        ec2_client = get_ec2_client(region)
-
-        # Get subnets
-        subnets_response = ec2_client.describe_subnets(
-            Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]
-        )
-
-        # Get all ENIs for this VPC
-        enis_response = ec2_client.describe_network_interfaces(
-            Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]
-        )
-
-        # Extract all IPs from ENIs (including secondary IPs and prefix delegation)
-        subnet_ip_details = get_all_eni_ips(enis_response['NetworkInterfaces'])
-
-        subnets = []
-        for subnet in subnets_response['Subnets']:
-            if subnet.get('Ipv6Native', False):
-                continue
-
-            subnet_id = subnet['SubnetId']
-            cidr_block = subnet['CidrBlock']
-
-            name = next((tag['Value'] for tag in subnet.get('Tags', [])
-                        if tag['Key'] == 'Name'), subnet_id)
-
-            # Calculate IP usage
-            network = ip_network(cidr_block)
-            total_ips = network.num_addresses
-            available_ips = subnet['AvailableIpAddressCount']
-
-            # Get used IPs from ENIs (including secondary IPs and prefixes)
-            ip_details = subnet_ip_details.get(subnet_id, [])
-            used_ips = [ip_info['ip'] for ip_info in ip_details]
-            reserved_ips = get_reserved_ips(cidr_block)
-
-            # Get CIDR reservations
-            cidr_reservation_ips = get_subnet_cidr_reservations(ec2_client, subnet_id)
-            cidr_reservations_list = list(cidr_reservation_ips.keys())
-
-            # Combine used IPs and CIDR reservations for fragmentation calculation
-            # CIDR reservations should be treated as unavailable space
-            all_unavailable_ips = used_ips + cidr_reservations_list
-
-            # Calculate fragmentation
-            logger.info(f"=== Calculating fragmentation for subnet: {name} ({subnet_id}) ===")
-            frag_score, frag_details = calculate_fragmentation(
-                all_unavailable_ips, total_ips, available_ips
-            )
-
-            # Count different IP types
-            primary_count = sum(1 for ip in ip_details if ip['type'] == 'primary')
-            secondary_count = sum(1 for ip in ip_details if ip['type'] == 'secondary')
-            prefix_count = sum(1 for ip in ip_details if ip['type'] == 'prefix_delegation')
-
-            # Extract unique CIDR reservation blocks for summary
-            reservation_blocks = {}
-            for ip_addr, res_info in cidr_reservation_ips.items():
-                res_cidr = res_info['cidr']
-                if res_cidr not in reservation_blocks:
-                    reservation_blocks[res_cidr] = res_info
-
-            subnets.append({
-                'id': subnet_id,
-                'name': name,
-                'cidr': cidr_block,
-                'availabilityZone': subnet['AvailabilityZone'],
-                'totalIps': total_ips,
-                'availableIps': available_ips,
-                'usedIps': len(used_ips),
-                'reservedIps': len(reserved_ips),
-                'cidrReservationIps': len(cidr_reservations_list),
-                'cidrReservations': list(reservation_blocks.values()),
-                'primaryIps': primary_count,
-                'secondaryIps': secondary_count,
-                'prefixDelegationIps': prefix_count,
-                'utilization': round((len(used_ips) / total_ips) * 100, 2) if total_ips > 0 else 0,
-                'fragmentationScore': frag_score,
-                'fragmentationDetails': frag_details
-            })
-
-        return jsonify(subnets)
+        return jsonify(get_vpc_subnets(vpc_id, region))
     except Exception as e:
         logger.error(f"Error fetching subnets: {str(e)}")
         return jsonify({'error': str(e)}), 500
@@ -394,74 +79,7 @@ def get_subnet_ips(subnet_id):
     """Get detailed IP allocation map for a subnet"""
     try:
         region = get_region_from_request()
-        ec2_client = get_ec2_client(region)
-
-        # Get subnet details
-        subnet_response = ec2_client.describe_subnets(SubnetIds=[subnet_id])
-        subnet = subnet_response['Subnets'][0]
-        cidr_block = subnet['CidrBlock']
-
-        # Get ENIs in this subnet
-        enis_response = ec2_client.describe_network_interfaces(
-            Filters=[{'Name': 'subnet-id', 'Values': [subnet_id]}]
-        )
-
-        # Collect all IPs from ENIs (including secondary and prefix delegation)
-        subnet_ip_details = get_all_eni_ips(enis_response['NetworkInterfaces'])
-        ip_details_map = {ip_info['ip']: ip_info for ip_info in subnet_ip_details.get(subnet_id, [])}
-
-        # Get reserved IPs (AWS system reserved)
-        reserved_ips = get_reserved_ips(cidr_block)
-
-        # Get CIDR reservations (explicit and prefix reservations)
-        cidr_reservation_ips = get_subnet_cidr_reservations(ec2_client, subnet_id)
-
-        # Build complete IP map
-        network = ip_network(cidr_block)
-        ip_map = []
-
-        for ip in network:
-            ip_str = str(ip)
-            if ip_str in reserved_ips:
-                status = 'reserved'
-                details = {'reason': 'AWS Reserved', 'type': 'aws_reserved'}
-            elif ip_str in ip_details_map:
-                # IP is in use - show as used even if in a CIDR reservation
-                status = 'used'
-                details = ip_details_map[ip_str]
-                # Add reservation info if this IP is also part of a CIDR reservation
-                if ip_str in cidr_reservation_ips:
-                    details['cidrReservation'] = cidr_reservation_ips[ip_str]
-            elif ip_str in cidr_reservation_ips:
-                # IP is reserved but not currently in use
-                status = 'cidr_reservation'
-                details = cidr_reservation_ips[ip_str]
-            else:
-                status = 'free'
-                details = None
-
-            ip_map.append({
-                'ip': ip_str,
-                'status': status,
-                'details': details
-            })
-
-        # Calculate statistics
-        used_count = sum(1 for ip in ip_map if ip['status'] == 'used')
-        free_count = sum(1 for ip in ip_map if ip['status'] == 'free')
-        reserved_count = sum(1 for ip in ip_map if ip['status'] == 'reserved')
-        cidr_reservation_count = sum(1 for ip in ip_map if ip['status'] == 'cidr_reservation')
-
-        return jsonify({
-            'subnetId': subnet_id,
-            'cidr': cidr_block,
-            'totalIps': len(ip_map),
-            'usedIps': used_count,
-            'freeIps': free_count,
-            'reservedIps': reserved_count,
-            'cidrReservationIps': cidr_reservation_count,
-            'ips': ip_map
-        })
+        return jsonify(get_subnet_ip_map(subnet_id, region))
     except Exception as e:
         logger.error(f"Error fetching subnet IPs: {str(e)}")
         return jsonify({'error': str(e)}), 500

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-CORS==4.0.0
 boto3==1.34.34
 python-dotenv==1.0.0
 gunicorn==21.2.0
+textual==0.85.2

--- a/tui.py
+++ b/tui.py
@@ -1,0 +1,552 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+
+"""
+Terminal UI for the VPC IP Fragmentation Viewer.
+
+A disk-defrag style, keyboard-driven view of AWS VPC IP allocation built on
+Textual. It reuses the same AWS querying + fragmentation logic as the Flask API
+(see vpc_data.py).
+
+Run with:
+    python tui.py
+    # or, once installed as part of requirements.txt:
+    textual run tui.py
+
+Requires AWS credentials in the environment (same as the web app) and the
+ec2:Describe* / ec2:GetSubnetCidrReservations permissions.
+"""
+
+import asyncio
+
+from rich.text import Text
+from textual import on, work
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, ScrollableContainer, Vertical
+from textual.message import Message
+from textual.widgets import (
+    DataTable,
+    Footer,
+    Header,
+    Label,
+    Select,
+    Static,
+)
+
+import vpc_data
+
+
+# Status -> hex color, mirroring the React IpVisualization palette.
+STATUS_COLORS = {
+    "used_primary": "#3b82f6",       # blue
+    "used_secondary": "#06b6d4",     # cyan
+    "used_prefix_delegation": "#8b5cf6",  # purple
+    "reserved": "#64748b",           # slate (AWS reserved)
+    "cidr_reservation_explicit": "#f59e0b",  # amber
+    "cidr_reservation_prefix": "#f97316",    # orange
+    "free": "#e2e8f0",               # light (free/available), like a defrag map
+}
+
+# Bright cursor color, distinct from every palette entry.
+CURSOR_COLOR = "#f472b6"  # pink
+
+# The legend shown on the Cluster Map header: (label, color).
+LEGEND = [
+    ("Primary", STATUS_COLORS["used_primary"]),
+    ("Secondary", STATUS_COLORS["used_secondary"]),
+    ("Prefix", STATUS_COLORS["used_prefix_delegation"]),
+    ("CIDR-Resv", STATUS_COLORS["cidr_reservation_explicit"]),
+    ("AWS-Resv", STATUS_COLORS["reserved"]),
+    ("Free", STATUS_COLORS["free"]),
+]
+
+
+def build_legend():
+    """A one-line legend of colored swatches, defrag-tool style."""
+    t = Text()
+    for label, color in LEGEND:
+        t.append("  ", style=f"on {color}")
+        t.append(f" {label} ")
+    t.append("  ", style=f"on {CURSOR_COLOR}")
+    t.append(" Cursor")
+    return t
+
+
+def ip_color(ip):
+    """Return the hex color for an IP-map entry."""
+    status = ip["status"]
+    details = ip.get("details") or {}
+    if status == "used":
+        t = details.get("type")
+        if t == "secondary":
+            return STATUS_COLORS["used_secondary"]
+        if t == "prefix_delegation":
+            return STATUS_COLORS["used_prefix_delegation"]
+        return STATUS_COLORS["used_primary"]
+    if status == "reserved":
+        return STATUS_COLORS["reserved"]
+    if status == "cidr_reservation":
+        if details.get("type") == "prefix":
+            return STATUS_COLORS["cidr_reservation_prefix"]
+        return STATUS_COLORS["cidr_reservation_explicit"]
+    return STATUS_COLORS["free"]
+
+
+class IpGrid(Static):
+    """A navigable disk-defrag style grid of IP blocks.
+
+    Arrow keys / hjkl move a cursor over the blocks; each move posts an
+    ``IpSelected`` message so a details panel can update (the TUI equivalent of
+    the web hover tooltip).
+    """
+
+    # Each cell is CELL_W chars wide with the gridlines baked into the glyphs
+    # (no separate gap column), so a row of N cells is exactly N*CELL_W chars.
+    # COLS is recomputed from the widget's width so the grid always fills the
+    # map panel horizontally.
+    CELL_W = 2
+    COLS = 32
+    can_focus = True
+
+    class Selected(Message):
+        """Posted when the grid cursor moves onto an IP entry."""
+
+        def __init__(self, ip):
+            self.ip = ip
+            super().__init__()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._ips = []
+        self.cursor = 0
+        self.COLS = type(self).COLS  # instance copy, resized to fit width
+
+    def set_ips(self, ips):
+        self._ips = ips or []
+        self.cursor = 0
+        self._fit_cols()
+        self.refresh_grid()
+        self._emit_selection()
+
+    def _fit_cols(self):
+        """Choose the largest column count whose row fits the current width."""
+        width = self.size.width
+        if width <= 0:
+            return False
+        cols = max(1, width // self.CELL_W)  # gridlines are baked into the cells
+        if cols != self.COLS:
+            self.COLS = cols
+            return True
+        return False
+
+    def on_resize(self, event):
+        # Reflow to fill the newly available width.
+        if self._fit_cols():
+            self.refresh_grid()
+
+    def refresh_grid(self):
+        self.update(self._render_grid())
+
+    def _render_grid(self):
+        if not self._ips:
+            return Text("Select a subnet to load its IP cluster map.", style="dim italic")
+
+        # Each IP is a 2-wide cell with both gridlines baked into the glyphs so
+        # the horizontal and vertical gaps are the same thin 1/8 of a character:
+        #   "▇" (lower seven-eighths) leaves a 1/8 dark sliver at the TOP    -> horizontal gridline
+        #   "▉" (left  seven-eighths) leaves a 1/8 dark sliver at the RIGHT  -> vertical gridline
+        # The two glyphs share the cell's color so it reads as one block, and
+        # cells sit flush against each other (no wasted blank column/row). The
+        # cursor is a solid "██" block so it stands out.
+        cell = "▇" * (self.CELL_W - 1) + "▉"
+        cursor = "█" * self.CELL_W
+        pad = " " * self.CELL_W
+        text = Text()
+        n = len(self._ips)
+        rows = (n + self.COLS - 1) // self.COLS
+        for r in range(rows):
+            for c in range(self.COLS):
+                i = r * self.COLS + c
+                if i >= n:
+                    text.append(pad)  # pad past the last IP
+                    continue
+                if i == self.cursor:
+                    text.append(cursor, style=CURSOR_COLOR)
+                else:
+                    text.append(cell, style=ip_color(self._ips[i]))
+            if r < rows - 1:
+                text.append("\n")
+        return text
+
+    def _clamp(self, value):
+        if not self._ips:
+            return 0
+        return max(0, min(value, len(self._ips) - 1))
+
+    def _emit_selection(self):
+        if self._ips:
+            self.post_message(IpGrid.Selected(self._ips[self.cursor]))
+
+    def on_key(self, event):
+        if not self._ips:
+            return
+        key = event.key
+        moved = True
+        if key in ("right", "l"):
+            self.cursor = self._clamp(self.cursor + 1)
+        elif key in ("left", "h"):
+            self.cursor = self._clamp(self.cursor - 1)
+        elif key in ("down", "j"):
+            self.cursor = self._clamp(self.cursor + self.COLS)
+        elif key in ("up", "k"):
+            self.cursor = self._clamp(self.cursor - self.COLS)
+        elif key == "home":
+            self.cursor = 0
+        elif key == "end":
+            self.cursor = len(self._ips) - 1
+        else:
+            moved = False
+        if moved:
+            event.stop()
+            event.prevent_default()
+            self.refresh_grid()
+            self._emit_selection()
+
+
+def frag_level(score):
+    """Map a fragmentation score to (label, color)."""
+    if score < 20:
+        return "Low", "#10b981"
+    if score < 50:
+        return "Moderate", "#f59e0b"
+    return "High", "#ef4444"
+
+
+class VpcFragTUI(App):
+    CSS = """
+    Screen {
+        background: #071a3f;
+        color: #e2e8f0;
+    }
+
+    Header {
+        background: #1d4ed8;
+        color: #ffffff;
+    }
+
+    #controls {
+        height: auto;
+        padding: 0 1;
+        background: #0b2a63;
+    }
+
+    #controls Select {
+        width: 1fr;
+    }
+
+    #status {
+        height: 1;
+        padding: 0 1;
+        color: #fbbf24;
+        background: #0b2a63;
+    }
+
+    #body {
+        height: 1fr;
+    }
+
+    /* Left: the big IP cluster map. The whole column is one bordered box so
+       its top/bottom edges line up with the stacked panels on the right. */
+    #left {
+        width: 62%;
+        border: round #3b82f6;
+        padding: 0 1;
+    }
+
+    #legend {
+        height: 1;
+    }
+
+    #grid-scroll {
+        height: 1fr;
+        background: #071a3f;
+        overflow-x: hidden;
+    }
+
+    #ip-grid {
+        width: 1fr;
+        height: auto;
+    }
+
+    #ip-details {
+        height: 2;
+        color: #93c5fd;
+    }
+
+    /* Right: statistics on top, subnet list below */
+    #right {
+        width: 38%;
+    }
+
+    #stats {
+        height: 45%;
+        padding: 0 1;
+        border: round #3b82f6;
+    }
+
+    #subnet-table {
+        height: 1fr;
+        border: round #3b82f6;
+    }
+
+    #subnet-table > .datatable--cursor {
+        background: #14b8a6;
+        color: #042f2e;
+    }
+    """
+
+    BINDINGS = [
+        ("r", "refresh", "Refresh"),
+        ("q", "quit", "Quit"),
+    ]
+
+    TITLE = "☁ VPC IP Fragmentation Viewer"
+
+    def __init__(self):
+        super().__init__()
+        self._subnets_by_id = {}
+        self._selected_subnet = None
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Horizontal(id="controls"):
+            yield Select([], prompt="Select region…", id="region-select")
+            yield Select([], prompt="Select VPC…", id="vpc-select")
+        yield Label("Loading regions…", id="status")
+        with Horizontal(id="body"):
+            with Vertical(id="left"):
+                yield Static(build_legend(), id="legend")
+                with ScrollableContainer(id="grid-scroll"):
+                    yield IpGrid(id="ip-grid")
+                yield Static("Move the cursor over the map to inspect an IP.", id="ip-details")
+            with Vertical(id="right"):
+                yield Static("Select a subnet to view statistics.", id="stats")
+                yield DataTable(id="subnet-table", cursor_type="row")
+        yield Footer()
+
+    def on_mount(self):
+        table = self.query_one("#subnet-table", DataTable)
+        table.add_columns("Name", "CIDR", "AZ", "Used", "Avail", "Util%", "Frag")
+        # Panel titles, defrag-tool style.
+        self.query_one("#left").border_title = "IP Cluster Map"
+        self.query_one("#stats", Static).border_title = "Subnet Statistics"
+        table.border_title = "Subnets"
+        self.load_regions()
+
+    def set_status(self, message):
+        self.query_one("#status", Label).update(message)
+
+    # ----- data loading workers -------------------------------------------
+
+    @work(exclusive=False)
+    async def load_regions(self):
+        self.set_status("Loading regions…")
+        try:
+            regions = await asyncio.to_thread(vpc_data.list_regions)
+        except Exception as e:
+            self.set_status(f"Error loading regions: {e}")
+            return
+        select = self.query_one("#region-select", Select)
+        select.set_options([(r["name"], r["id"]) for r in regions])
+        default = next((r["id"] for r in regions if r["id"] == vpc_data.DEFAULT_REGION), None)
+        if default:
+            select.value = default
+        else:
+            self.set_status("Select a region to begin.")
+
+    @work(exclusive=True)
+    async def load_vpcs(self, region):
+        self.set_status(f"Loading VPCs in {region}…")
+        try:
+            vpcs = await asyncio.to_thread(vpc_data.list_vpcs, region)
+        except Exception as e:
+            self.set_status(f"Error loading VPCs: {e}")
+            return
+        select = self.query_one("#vpc-select", Select)
+        options = [(f"{v['name']} ({v['cidr']})", v["id"]) for v in vpcs]
+        select.set_options(options)
+        select.value = Select.BLANK
+        self.set_status(f"{len(vpcs)} VPC(s) in {region}. Select a VPC.")
+
+    @work(exclusive=True)
+    async def load_subnets(self, region, vpc_id):
+        self.set_status(f"Loading subnets for {vpc_id}…")
+        table = self.query_one("#subnet-table", DataTable)
+        table.clear()
+        self._subnets_by_id = {}
+        try:
+            subnets = await asyncio.to_thread(vpc_data.get_vpc_subnets, vpc_id, region)
+        except Exception as e:
+            self.set_status(f"Error loading subnets: {e}")
+            return
+        for s in subnets:
+            self._subnets_by_id[s["id"]] = s
+            label, _ = frag_level(s["fragmentationScore"])
+            table.add_row(
+                s["name"],
+                s["cidr"],
+                s["availabilityZone"],
+                str(s["usedIps"]),
+                str(s["availableIps"]),
+                f"{s['utilization']:.1f}",
+                f"{s['fragmentationScore']:.0f} {label}",
+                key=s["id"],
+            )
+        self.set_status(f"{len(subnets)} subnet(s). Select one to view its IP map.")
+
+    @work(exclusive=True)
+    async def load_ip_map(self, region, subnet_id):
+        self.set_status(f"Loading IP map for {subnet_id}…")
+        try:
+            data = await asyncio.to_thread(vpc_data.get_subnet_ip_map, subnet_id, region)
+        except Exception as e:
+            self.set_status(f"Error loading IP map: {e}")
+            return
+        self.query_one("#ip-grid", IpGrid).set_ips(data["ips"])
+        self._render_stats(self._subnets_by_id.get(subnet_id), data)
+        self.query_one("#grid-scroll").scroll_home(animate=False)
+        self.set_status(
+            f"{data['totalIps']} IPs — {data['usedIps']} used, "
+            f"{data['freeIps']} free, {data['reservedIps']} AWS-reserved, "
+            f"{data['cidrReservationIps']} CIDR-reserved."
+        )
+
+    # ----- rendering helpers ----------------------------------------------
+
+    def _render_stats(self, subnet, ip_data):
+        if not subnet:
+            return
+        d = subnet.get("fragmentationDetails") or {}
+        label, color = frag_level(subnet["fragmentationScore"])
+
+        t = Text()
+        t.append(f"{subnet['name']}\n", style="bold")
+        t.append(f"{subnet['id']}  •  {subnet['cidr']}  •  {subnet['availabilityZone']}\n\n",
+                 style="dim")
+
+        t.append("Allocation   ", style="bold")
+        t.append(
+            f"total {subnet['totalIps']}   used {subnet['usedIps']}   "
+            f"avail {subnet['availableIps']}   reserved {subnet['reservedIps']}   "
+            f"util {subnet['utilization']:.1f}%\n"
+        )
+        t.append("IP types     ", style="bold")
+        t.append(
+            f"primary {subnet['primaryIps']}   secondary {subnet['secondaryIps']}   "
+            f"prefix-deleg {subnet['prefixDelegationIps']}   "
+            f"cidr-resv {subnet['cidrReservationIps']}\n"
+        )
+        t.append("Fragmentation ", style="bold")
+        t.append(f"{subnet['fragmentationScore']:.1f} ", style=f"bold {color}")
+        t.append(f"({label})\n", style=color)
+        t.append(
+            f"  gaps {d.get('num_gaps', 0)}   "
+            f"largest-free {d.get('largest_gap', 0)}   "
+            f"avg-gap {d.get('avg_gap_size', 0)}   "
+            f"usable /28 {d.get('usable_prefixes', 0)}\n"
+        )
+        self.query_one("#stats", Static).update(t)
+
+    def _render_ip_details(self, ip):
+        t = Text()
+        t.append(f"{ip['ip']}  ", style="bold")
+        color = ip_color(ip)
+        details = ip.get("details") or {}
+        status = ip["status"]
+
+        if status == "used":
+            typ = details.get("type", "used")
+            t.append(f"[{typ}]", style=color)
+            eni = details.get("interfaceId")
+            if eni:
+                t.append(f"  ENI {eni}", style="dim")
+            desc = details.get("description")
+            if desc:
+                t.append(f"\n  {desc}", style="dim")
+            resv = details.get("cidrReservation")
+            if resv:
+                t.append(
+                    f"\n  ↳ in CIDR reservation {resv.get('cidr')} ({resv.get('type')})",
+                    style=STATUS_COLORS["cidr_reservation_explicit"],
+                )
+        elif status == "reserved":
+            t.append("[AWS reserved]", style=color)
+        elif status == "cidr_reservation":
+            t.append(f"[CIDR reservation • {details.get('type')}]", style=color)
+            t.append(f"  block {details.get('cidr')}", style="dim")
+            if details.get("description"):
+                t.append(f"\n  {details['description']}", style="dim")
+            if details.get("reservationId"):
+                t.append(f"\n  {details['reservationId']}", style="dim")
+        else:
+            t.append("[free / available]", style=color)
+
+        self.query_one("#ip-details", Static).update(t)
+
+    # ----- event handlers -------------------------------------------------
+
+    @on(Select.Changed, "#region-select")
+    def _region_changed(self, event):
+        if event.value is Select.BLANK:
+            return
+        # Reset downstream selections.
+        self.query_one("#vpc-select", Select).set_options([])
+        self.query_one("#subnet-table", DataTable).clear()
+        self.query_one("#ip-grid", IpGrid).set_ips([])
+        self.load_vpcs(event.value)
+
+    @on(Select.Changed, "#vpc-select")
+    def _vpc_changed(self, event):
+        if event.value is Select.BLANK:
+            return
+        region = self.query_one("#region-select", Select).value
+        self.query_one("#ip-grid", IpGrid).set_ips([])
+        self.load_subnets(region, event.value)
+
+    @on(DataTable.RowSelected, "#subnet-table")
+    def _subnet_selected(self, event):
+        subnet_id = event.row_key.value
+        if not subnet_id:
+            return
+        self._selected_subnet = subnet_id
+        region = self.query_one("#region-select", Select).value
+        self.query_one("#ip-grid", IpGrid).focus()
+        self.load_ip_map(region, subnet_id)
+
+    @on(IpGrid.Selected)
+    def _ip_hovered(self, event):
+        self._render_ip_details(event.ip)
+
+    # ----- actions --------------------------------------------------------
+
+    def action_refresh(self):
+        region = self.query_one("#region-select", Select).value
+        vpc = self.query_one("#vpc-select", Select).value
+        if self._selected_subnet and region is not Select.BLANK:
+            self.load_ip_map(region, self._selected_subnet)
+        elif vpc is not Select.BLANK and region is not Select.BLANK:
+            self.load_subnets(region, vpc)
+        elif region is not Select.BLANK:
+            self.load_vpcs(region)
+        else:
+            self.load_regions()
+
+
+def main():
+    VpcFragTUI().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/vpc_data.py
+++ b/vpc_data.py
@@ -1,0 +1,432 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+
+"""
+Shared VPC IP data + fragmentation logic.
+
+This module contains the AWS EC2 querying and fragmentation-analysis logic used
+by both the Flask API (app.py) and the terminal UI (tui.py). Keeping it here
+avoids duplicating boto3 calls and the fragmentation math across front ends.
+"""
+
+import logging
+import os
+from ipaddress import ip_network, ip_address
+from collections import defaultdict
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+# Default region
+DEFAULT_REGION = os.getenv('AWS_DEFAULT_REGION', 'us-east-1')
+
+# /28 block size for EKS prefix delegation
+PREFIX_SIZE = 16
+
+
+def get_ec2_client(region=None):
+    """Get EC2 client for the specified region"""
+    region = region or DEFAULT_REGION
+    return boto3.client('ec2', region_name=region)
+
+
+def get_reserved_ips(cidr_block):
+    """AWS reserves first 4 and last IP in each subnet"""
+    network = ip_network(cidr_block)
+    reserved = set()
+
+    # First 4 IPs (.0, .1, .2, .3) and last IP (broadcast)
+    reserved.add(str(network.network_address))
+    reserved.add(str(network.network_address + 1))
+    reserved.add(str(network.network_address + 2))
+    reserved.add(str(network.network_address + 3))
+    reserved.add(str(network.broadcast_address))
+
+    return reserved
+
+
+def get_subnet_cidr_reservations(ec2_client, subnet_id):
+    """
+    Get CIDR reservations for a subnet.
+    Returns a dict mapping IP addresses to reservation details.
+    """
+    try:
+        response = ec2_client.get_subnet_cidr_reservations(SubnetId=subnet_id)
+
+        reservation_ips = {}
+        for reservation in response.get('SubnetIpv4CidrReservations', []):
+            cidr = reservation['Cidr']
+            reservation_type = reservation['ReservationType']  # 'explicit' or 'prefix'
+            description = reservation.get('Description', '')
+            reservation_id = reservation['SubnetCidrReservationId']
+
+            logger.info(f"Found CIDR reservation: {cidr} ({reservation_type}) - {description}")
+
+            # Get all IPs in the reserved CIDR block
+            try:
+                reserved_network = ip_network(cidr)
+                for ip in reserved_network:
+                    reservation_ips[str(ip)] = {
+                        'cidr': cidr,
+                        'type': reservation_type,
+                        'description': description,
+                        'reservationId': reservation_id
+                    }
+            except Exception as e:
+                logger.error(f"Error processing reservation CIDR {cidr}: {str(e)}")
+
+        return reservation_ips
+    except Exception as e:
+        logger.error(f"Error fetching subnet CIDR reservations: {str(e)}")
+        return {}
+
+
+def get_all_eni_ips(enis):
+    """
+    Extract all IPs from ENIs including:
+    - Primary private IPs
+    - Secondary private IPs (used by EKS pods without dedicated ENIs)
+    - IPs from IPv4 prefixes (prefix delegation for EKS)
+    """
+    subnet_ips = defaultdict(list)
+
+    for eni in enis:
+        subnet_id = eni['SubnetId']
+        interface_id = eni['NetworkInterfaceId']
+        description = eni.get('Description', '')
+
+        # Get all private IP addresses (primary and secondary)
+        for private_ip_info in eni.get('PrivateIpAddresses', []):
+            ip = private_ip_info['PrivateIpAddress']
+            subnet_ips[subnet_id].append({
+                'ip': ip,
+                'type': 'primary' if private_ip_info.get('Primary', False) else 'secondary',
+                'status': eni['Status'],
+                'description': description,
+                'interfaceId': interface_id,
+                'attachmentStatus': eni.get('Attachment', {}).get('Status', 'detached')
+            })
+
+        # Get IPs from IPv4 prefixes (EKS prefix delegation)
+        for prefix in eni.get('Ipv4Prefixes', []):
+            prefix_cidr = prefix['Ipv4Prefix']
+            logger.info(f"Found IPv4 prefix: {prefix_cidr} on ENI {interface_id}")
+
+            # Each prefix is typically a /28 (16 IPs) assigned to the ENI
+            # Pods will use IPs from this prefix
+            try:
+                prefix_network = ip_network(prefix_cidr)
+                for ip in prefix_network.hosts():
+                    subnet_ips[subnet_id].append({
+                        'ip': str(ip),
+                        'type': 'prefix_delegation',
+                        'status': 'prefix',
+                        'description': f"{description} (Prefix: {prefix_cidr})",
+                        'interfaceId': interface_id,
+                        'attachmentStatus': 'prefix_assigned'
+                    })
+            except Exception as e:
+                logger.error(f"Error processing prefix {prefix_cidr}: {str(e)}")
+
+    return subnet_ips
+
+
+def calculate_fragmentation(used_ips, total_ips, available_count):
+    """
+    Calculate fragmentation metrics for a subnet optimized for /28 prefix allocation.
+    Returns a fragmentation score (0-100) where:
+    - 0 = Low fragmentation (can allocate many /28 blocks efficiently)
+    - 100 = High fragmentation (most available IPs are wasted in unusable fragments)
+
+    The score measures what percentage of available IPs are in fragments too small
+    to fit a /28 block (16 IPs). This directly reflects allocation efficiency.
+    """
+    if total_ips == 0 or available_count == 0:
+        return 0, {'num_gaps': 0, 'avg_gap_size': 0, 'largest_gap': 0, 'gaps': [], 'usable_prefixes': 0}
+
+    if len(used_ips) == 0:
+        # No IPs used means no fragmentation
+        usable_prefixes = available_count // PREFIX_SIZE
+        return 0, {
+            'num_gaps': 0,
+            'avg_gap_size': 0,
+            'largest_gap': available_count,
+            'gaps': [],
+            'usable_prefixes': usable_prefixes
+        }
+
+    # Sort used IPs by their integer representation
+    sorted_used = sorted([int(ip_address(ip)) for ip in used_ips])
+
+    logger.info(f"Fragmentation calc: total_ips={total_ips}, available={available_count}, used={len(used_ips)}")
+    logger.info(f"Used IP range: {ip_address(sorted_used[0])} to {ip_address(sorted_used[-1])}")
+
+    # Find all free blocks (gaps between used IPs + edge space)
+    gaps = []
+    for i in range(len(sorted_used) - 1):
+        gap_size = sorted_used[i + 1] - sorted_used[i] - 1
+        if gap_size > 0:
+            gaps.append(gap_size)
+
+    # Total IPs in gaps between used IPs
+    total_gap_ips = sum(gaps)
+
+    # The remaining available IPs are in contiguous blocks outside the used IP range
+    edge_free_ips = available_count - total_gap_ips
+
+    # All free blocks = gaps + edge block
+    all_free_blocks = gaps + ([edge_free_ips] if edge_free_ips > 0 else [])
+
+    # Calculate how many /28 prefixes can actually be allocated
+    usable_prefixes = sum(block // PREFIX_SIZE for block in all_free_blocks)
+
+    # Calculate how many /28 prefixes COULD be allocated if perfectly contiguous
+    theoretical_prefixes = available_count // PREFIX_SIZE
+
+    # Calculate wasted IPs (IPs in fragments too small for /28)
+    wasted_ips = sum(block % PREFIX_SIZE if block < PREFIX_SIZE else 0
+                     for block in all_free_blocks)
+    # Add the remainder IPs from blocks that can fit prefixes
+    wasted_ips += sum(block % PREFIX_SIZE for block in all_free_blocks if block >= PREFIX_SIZE)
+
+    logger.info(f"Gaps: {len(gaps)} gaps totaling {total_gap_ips} IPs")
+    logger.info(f"Free blocks: {sorted(all_free_blocks, reverse=True)[:5]}")
+    logger.info(f"Can allocate {usable_prefixes} /28 prefixes (theoretical max: {theoretical_prefixes})")
+    logger.info(f"Wasted IPs: {wasted_ips}/{available_count}")
+
+    # Calculate metrics
+    num_free_blocks = len(all_free_blocks)
+    largest_free_block = max(all_free_blocks) if all_free_blocks else 0
+    avg_block_size = sum(all_free_blocks) / num_free_blocks if num_free_blocks > 0 else 0
+
+    # If all free space is in one block, fragmentation is minimal
+    if num_free_blocks <= 1:
+        # Still calculate score based on wasted remainder
+        waste_percentage = (wasted_ips / available_count) * 100 if available_count > 0 else 0
+        return round(waste_percentage, 2), {
+            'num_gaps': 0,
+            'avg_gap_size': 0,
+            'largest_gap': largest_free_block,
+            'gaps': [],
+            'usable_prefixes': usable_prefixes
+        }
+
+    # Fragmentation score: percentage of IPs that can't be used due to fragmentation
+    # This accounts for both small fragments AND remainder waste
+    if theoretical_prefixes > 0:
+        # How many prefixes are lost due to fragmentation?
+        lost_prefixes = theoretical_prefixes - usable_prefixes
+        fragmentation_score = (lost_prefixes / theoretical_prefixes) * 100
+    else:
+        # If we can't even fit one /28, fragmentation is maximum
+        fragmentation_score = 100
+
+    logger.info(f"Fragmentation score: {fragmentation_score:.1f}% (lost {theoretical_prefixes - usable_prefixes}/{theoretical_prefixes} possible /28 blocks)")
+
+    return round(fragmentation_score, 2), {
+        'num_gaps': len(gaps),
+        'avg_gap_size': round(avg_block_size, 2),
+        'largest_gap': largest_free_block,
+        'gaps': sorted(all_free_blocks, reverse=True)[:10],
+        'usable_prefixes': usable_prefixes
+    }
+
+
+# ---------------------------------------------------------------------------
+# High-level aggregations (region -> vpc -> subnet -> ip map)
+# ---------------------------------------------------------------------------
+
+def list_regions():
+    """Return all enabled AWS regions as a sorted list of dicts."""
+    ec2_client = boto3.client('ec2', region_name='us-east-1')
+    response = ec2_client.describe_regions(AllRegions=False)
+    regions = [
+        {
+            'id': region['RegionName'],
+            'name': region['RegionName'],
+            'endpoint': region['Endpoint']
+        }
+        for region in response['Regions']
+    ]
+    regions.sort(key=lambda x: x['name'])
+    return regions
+
+
+def list_vpcs(region=None):
+    """Return all VPCs in the account for the specified region."""
+    ec2_client = get_ec2_client(region)
+    response = ec2_client.describe_vpcs()
+    vpcs = []
+
+    for vpc in response['Vpcs']:
+        name = next((tag['Value'] for tag in vpc.get('Tags', [])
+                    if tag['Key'] == 'Name'), vpc['VpcId'])
+        vpcs.append({
+            'id': vpc['VpcId'],
+            'name': name,
+            'cidr': vpc['CidrBlock'],
+            'state': vpc['State']
+        })
+
+    return vpcs
+
+
+def get_vpc_subnets(vpc_id, region=None):
+    """Return all subnets for a VPC with usage + fragmentation statistics."""
+    ec2_client = get_ec2_client(region)
+
+    # Get subnets
+    subnets_response = ec2_client.describe_subnets(
+        Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]
+    )
+
+    # Get all ENIs for this VPC
+    enis_response = ec2_client.describe_network_interfaces(
+        Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]
+    )
+
+    # Extract all IPs from ENIs (including secondary IPs and prefix delegation)
+    subnet_ip_details = get_all_eni_ips(enis_response['NetworkInterfaces'])
+
+    subnets = []
+    for subnet in subnets_response['Subnets']:
+        if subnet.get('Ipv6Native', False):
+            continue
+
+        subnet_id = subnet['SubnetId']
+        cidr_block = subnet['CidrBlock']
+
+        name = next((tag['Value'] for tag in subnet.get('Tags', [])
+                    if tag['Key'] == 'Name'), subnet_id)
+
+        # Calculate IP usage
+        network = ip_network(cidr_block)
+        total_ips = network.num_addresses
+        available_ips = subnet['AvailableIpAddressCount']
+
+        # Get used IPs from ENIs (including secondary IPs and prefixes)
+        ip_details = subnet_ip_details.get(subnet_id, [])
+        used_ips = [ip_info['ip'] for ip_info in ip_details]
+        reserved_ips = get_reserved_ips(cidr_block)
+
+        # Get CIDR reservations
+        cidr_reservation_ips = get_subnet_cidr_reservations(ec2_client, subnet_id)
+        cidr_reservations_list = list(cidr_reservation_ips.keys())
+
+        # Combine used IPs and CIDR reservations for fragmentation calculation
+        # CIDR reservations should be treated as unavailable space
+        all_unavailable_ips = used_ips + cidr_reservations_list
+
+        # Calculate fragmentation
+        logger.info(f"=== Calculating fragmentation for subnet: {name} ({subnet_id}) ===")
+        frag_score, frag_details = calculate_fragmentation(
+            all_unavailable_ips, total_ips, available_ips
+        )
+
+        # Count different IP types
+        primary_count = sum(1 for ip in ip_details if ip['type'] == 'primary')
+        secondary_count = sum(1 for ip in ip_details if ip['type'] == 'secondary')
+        prefix_count = sum(1 for ip in ip_details if ip['type'] == 'prefix_delegation')
+
+        # Extract unique CIDR reservation blocks for summary
+        reservation_blocks = {}
+        for ip_addr, res_info in cidr_reservation_ips.items():
+            res_cidr = res_info['cidr']
+            if res_cidr not in reservation_blocks:
+                reservation_blocks[res_cidr] = res_info
+
+        subnets.append({
+            'id': subnet_id,
+            'name': name,
+            'cidr': cidr_block,
+            'availabilityZone': subnet['AvailabilityZone'],
+            'totalIps': total_ips,
+            'availableIps': available_ips,
+            'usedIps': len(used_ips),
+            'reservedIps': len(reserved_ips),
+            'cidrReservationIps': len(cidr_reservations_list),
+            'cidrReservations': list(reservation_blocks.values()),
+            'primaryIps': primary_count,
+            'secondaryIps': secondary_count,
+            'prefixDelegationIps': prefix_count,
+            'utilization': round((len(used_ips) / total_ips) * 100, 2) if total_ips > 0 else 0,
+            'fragmentationScore': frag_score,
+            'fragmentationDetails': frag_details
+        })
+
+    return subnets
+
+
+def get_subnet_ip_map(subnet_id, region=None):
+    """Return the detailed per-IP allocation map for a subnet."""
+    ec2_client = get_ec2_client(region)
+
+    # Get subnet details
+    subnet_response = ec2_client.describe_subnets(SubnetIds=[subnet_id])
+    subnet = subnet_response['Subnets'][0]
+    cidr_block = subnet['CidrBlock']
+
+    # Get ENIs in this subnet
+    enis_response = ec2_client.describe_network_interfaces(
+        Filters=[{'Name': 'subnet-id', 'Values': [subnet_id]}]
+    )
+
+    # Collect all IPs from ENIs (including secondary and prefix delegation)
+    subnet_ip_details = get_all_eni_ips(enis_response['NetworkInterfaces'])
+    ip_details_map = {ip_info['ip']: ip_info for ip_info in subnet_ip_details.get(subnet_id, [])}
+
+    # Get reserved IPs (AWS system reserved)
+    reserved_ips = get_reserved_ips(cidr_block)
+
+    # Get CIDR reservations (explicit and prefix reservations)
+    cidr_reservation_ips = get_subnet_cidr_reservations(ec2_client, subnet_id)
+
+    # Build complete IP map
+    network = ip_network(cidr_block)
+    ip_map = []
+
+    for ip in network:
+        ip_str = str(ip)
+        if ip_str in reserved_ips:
+            status = 'reserved'
+            details = {'reason': 'AWS Reserved', 'type': 'aws_reserved'}
+        elif ip_str in ip_details_map:
+            # IP is in use - show as used even if in a CIDR reservation
+            status = 'used'
+            details = ip_details_map[ip_str]
+            # Add reservation info if this IP is also part of a CIDR reservation
+            if ip_str in cidr_reservation_ips:
+                details['cidrReservation'] = cidr_reservation_ips[ip_str]
+        elif ip_str in cidr_reservation_ips:
+            # IP is reserved but not currently in use
+            status = 'cidr_reservation'
+            details = cidr_reservation_ips[ip_str]
+        else:
+            status = 'free'
+            details = None
+
+        ip_map.append({
+            'ip': ip_str,
+            'status': status,
+            'details': details
+        })
+
+    # Calculate statistics
+    used_count = sum(1 for ip in ip_map if ip['status'] == 'used')
+    free_count = sum(1 for ip in ip_map if ip['status'] == 'free')
+    reserved_count = sum(1 for ip in ip_map if ip['status'] == 'reserved')
+    cidr_reservation_count = sum(1 for ip in ip_map if ip['status'] == 'cidr_reservation')
+
+    return {
+        'subnetId': subnet_id,
+        'cidr': cidr_block,
+        'totalIps': len(ip_map),
+        'usedIps': used_count,
+        'freeIps': free_count,
+        'reservedIps': reserved_count,
+        'cidrReservationIps': cidr_reservation_count,
+        'ips': ip_map
+    }


### PR DESCRIPTION
## Summary

Adds a keyboard-driven terminal UI for the VPC IP Fragmentation Viewer and refactors the AWS logic into a shared module so the TUI and the Flask web app stay in sync.

- **`tui.py`** — a disk-defrag-style Textual app. Renders an **IP Cluster Map** of colored cells (gridlines baked into the glyphs so horizontal/vertical spacing match), a **Subnet Statistics** panel, and a selectable **Subnets** list. The grid reflows to fill the panel width, and moving the cursor (arrows / `hjkl`, `Home`/`End`) shows per-IP details — the TUI equivalent of the web hover tooltip.
- **`vpc_data.py`** — extracts the boto3 EC2 queries and fragmentation math, now shared by both the Flask API and the TUI (no duplication).
- **`app.py`** — slimmed to thin Flask routes that call `vpc_data`; API surface unchanged.
- **`requirements.txt`** — adds `textual`.
- **`README.md`** — documents the TUI and the shared-core architecture.

## Testing

- All modules compile and import.
- Headless Textual `run_test` pilots: full flow (region → VPC → subnet → map + stats), grid navigation with boundaries, dynamic column reflow, and the per-IP selection message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)